### PR TITLE
Issue#1/breadcrumbs filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Cata Breadcrumbs
+Add a function with a filter to get breadcrumbs.

--- a/cata-breadcrumbs.php
+++ b/cata-breadcrumbs.php
@@ -12,7 +12,7 @@
  * Description: Add a function with a filter to get breadcrumbs.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.1.0
+ * Version:     0.1.0-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-breadcrumbs.php
+++ b/cata-breadcrumbs.php
@@ -25,8 +25,8 @@ namespace Cata\Breadcrumbs;
 require_once __DIR__ . '/includes/global-functions.php';
 
 /**
- * Category Breadcrumbs
+ * Category Crumb
  */
-require_once __DIR__ . '/includes/category/class-category.php';
+require_once __DIR__ . '/includes/category-crumb/class-category-crumb.php';
 
-new Category();
+new Category_Crumb();

--- a/cata-breadcrumbs.php
+++ b/cata-breadcrumbs.php
@@ -12,7 +12,7 @@
  * Description: Add a function with a filter to get breadcrumbs.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.1.0-beta1
+ * Version:     0.1.0-beta2
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-breadcrumbs.php
+++ b/cata-breadcrumbs.php
@@ -12,7 +12,7 @@
  * Description: Add a function with a filter to get breadcrumbs.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.1.0-beta2
+ * Version:     0.1.0
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-breadcrumbs.php
+++ b/cata-breadcrumbs.php
@@ -9,10 +9,19 @@
  *
  * @wordpress-plugin
  * Plugin Name: Cata Breadcrumbs
- * Description: Add breadcrumbs to pages & posts.
+ * Description: Add a function with a filter to get breadcrumbs.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
  * Version:     0.1.0
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */
+
+/**
+ * Get Cata Breadcrumbs
+ * 
+ * @return array
+ */
+function get_cata_breadcrumbs(): array {
+	return apply_filters( 'get_cata_breadcrumbs', array() );
+}

--- a/cata-breadcrumbs.php
+++ b/cata-breadcrumbs.php
@@ -17,11 +17,16 @@
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */
 
+namespace Cata\Breadcrumbs;
+
 /**
- * Get Cata Breadcrumbs
- * 
- * @return array
+ * Global Functions
  */
-function get_cata_breadcrumbs(): array {
-	return apply_filters( 'get_cata_breadcrumbs', array() );
-}
+require_once __DIR__ . '/includes/global-functions.php';
+
+/**
+ * Category Breadcrumbs
+ */
+require_once __DIR__ . '/includes/category/class-category.php';
+
+new Category();

--- a/includes/category-crumb/class-category-crumb.php
+++ b/includes/category-crumb/class-category-crumb.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Category
+ * Category Crumb
  *
  * @package Cata\Breadcrumbs
  */
@@ -10,9 +10,9 @@ namespace Cata\Breadcrumbs;
 use WP_Term;
 
 /**
- * Category
+ * Category Crumb
  */
-class Category {
+class Category_Crumb {
 	/**
 	 * Disallow
 	 *

--- a/includes/category/class-category.php
+++ b/includes/category/class-category.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Category
+ *
+ * @package Cata\Breadcrumbs
+ */
+
+namespace Cata\Breadcrumbs;
+
+use WP_Term;
+
+/**
+ * Category
+ */
+class Category {
+	/**
+	 * Disallow
+	 *
+	 * @var array
+	 */
+	const DISALLOW = array(
+		'uncategorized',
+	);
+
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'cata_breadcrumbs_get_crumbs', array( __CLASS__, 'add_category' ), 20, 2 );
+	}
+
+	/**
+	 * Add Category
+	 *
+	 * @param array $crumbs - array of breadcrumb items.
+	 * @param int   $post_id - post we're using to make the breadcrumb.
+	 * 
+	 * @return array $crumbs - updated with the primary category.
+	 */
+	public static function add_category( array $crumbs, int $post_id ): array {
+		$blacklist = apply_filters( 'cata_breadcrumbs_disallowed_category_slugs', self::DISALLOW );
+
+		if ( ! empty( $crumbs ) ) {
+			$blacklist = array_merge( $blacklist, array_column( $crumbs, 'slug' ) );
+		}
+
+		$category = self::get_primary_category( $post_id, $blacklist );
+
+		if ( ! $category instanceof WP_Term ) {
+			return $crumbs;
+		}
+
+		$crumb = array(
+			'slug'  => $category->slug,
+			'url'   => get_term_link( $category, 'category' ),
+			'title' => $category->name,
+		);
+
+		$crumb = apply_filters( 'cata_breadcrumbs_category_crumb', $crumb, $category );
+
+		return array_merge( array( $crumb ), $crumbs );
+	}
+
+	/**
+	 * Get Primary Category
+	 * 
+	 * @param int $post_id
+	 * @param array $unusable_term_slugs
+	 * 
+	 * @return WP_Term|null Either a WP_Term null false
+	 */
+	public static function get_primary_category( int $post_id, array $unusable_term_slugs = array() ): ?WP_Term {
+		$terms = get_the_terms( $post_id, 'category' );
+
+		if ( ! is_array( $terms ) || empty( $terms ) ) {
+			return null;
+		}
+
+		$usable_terms = array_values(
+			array_filter( $terms, function( $term ) use ( $unusable_term_slugs ) {
+				return ! in_array( $term->slug, $unusable_term_slugs, true );
+			})
+		);
+
+		if ( empty( $usable_terms ) ) {
+			return null;
+		}
+
+		return array_shift( $usable_terms );
+	}
+}

--- a/includes/global-functions.php
+++ b/includes/global-functions.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Global Functions
+ * 
+ * @package Cata\Breadcrumbs
+ * @since 0.1.0
+ */
+
+/**
+ * Get Cata Breadcrumbs
+ * 
+ * @return array
+ */
+function cata_breadcrumbs_get_crumbs(): array {
+	return apply_filters( 'cata_breadcrumbs_get_crumbs', array(), get_the_ID() );
+}


### PR DESCRIPTION
### Related Issues
- Closes #1 

### What Was Accomplished
- Adds a primary category as a breadcrumb
- Includes a global function to get breadcrumbs, which can be used in our themes when rendering breadcrumbs
- Includes a filter for breadcrumbs so themes can add more crumbs. This filter is also used by the SEO plugin to render structured data for breadcrumbs.

### How It Was Tested
- [x] Locally on parent theme
- [x] Locally on child theme
- [x] Child theme develop (Thoughtnet)

### How To Test
- Breadcrumb structured data appears in the footer on posts with a category that have both the Cata Breadcrumbs and the Cata SEO plugins active
- On Collective World develop, I added several test filters & debug output to the `single.php` template to check if the filters from the plugin work properly

### Open Questions
- Note that Thoughtnet currently has a plugin named Cata Breadcrumbs. I changed this on develop to Thoughtnet Breadcrumbs.